### PR TITLE
fix sometime address convert failure

### DIFF
--- a/burst-address.py
+++ b/burst-address.py
@@ -50,12 +50,12 @@ class ReedSolomon:
     def encode(self, plain):
         plain_string = str(plain);
         length = len(plain_string);
-        plain_string_10 = [None]*20;
+        plain_string_10 = [0]*20;
         for i in range(length):
             plain_string_10[i] = ord(plain_string[i]) - ord('0');
 
         codeword_length = 0;
-        codeword = [None]*len(self.initial_codeword);
+        codeword = [0]*len(self.initial_codeword);
 
         while True: # emulating do ... while from java
             new_length = 0;
@@ -141,8 +141,10 @@ while i>=0:
     address += bytesum;
     i-=1;
 
-# print long id
-print("Long id = \"%s\""%(address));
+# print long id and account number id
+print("Long id = \"%s\""%(address if address <= 2**63-1 else address - 2**64));
+
+print("Number id = \"%s\""%(address));
 
 ###### get reed-solomon for account
 


### PR DESCRIPTION
fix Issue#1, result as below:

```
Passphrase = "passphrase for account"
Long id = "-7600918943167756995"
Number id = "10845825130541794621"
RS id = "BURST-7KBX-HSEZ-SWY8-BW23F"
```

```
Passphrase = "surround plate beg strong"
Long id = "1025556839682832298"
Number id = "1025556839682832298"
RS id = "BURST-AXXC-JED6-KZ5G-24WGW"
```

```
Passphrase = "surely page seven vein"
Long id = "950697768627137920"
Number id = "950697768627137920"
RS id = "BURST-FVE2-LPKW-JHER-2GEEU"
```
